### PR TITLE
fix #23 checkFullPageScreen does not work correctly on small pages wi…

### DIFF
--- a/index.js
+++ b/index.js
@@ -270,7 +270,7 @@ class protractorImageComparison {
 
         if (this.isLastScreenshot) {
             desktopCropData.cropHeight = this.fullPageHeight - cropParameters.previousVerticalCoordinate;
-            desktopCropData.cropTopPosition = this.viewPortHeight - desktopCropData.cropHeight;
+            desktopCropData.cropTopPosition = cropParameters.currentScreenshotNumber > 1 ? this.viewPortHeight - desktopCropData.cropHeight : 0;
         } else {
             desktopCropData.cropHeight = this.viewPortHeight;
             desktopCropData.cropTopPosition = 0;


### PR DESCRIPTION
fix #23 by evaluating to `0` when it is no multi-image-screenshot, so the screenshot gets cropped correctly.