### PR TITLE
small fix for options parsing in _executeImageComparison

### DIFF
--- a/index.js
+++ b/index.js
@@ -351,7 +351,7 @@ class protractorImageComparison {
         // comparison options are not available anymore, due to new version and api
         compareOptions.ignoreAntialiasing = 'ignoreAntialiasing' in compareOptions ? compareOptions.ignoreAntialiasing : this.ignoreAntialiasing;
         compareOptions.ignoreColors = 'ignoreColors' in compareOptions ? compareOptions.ignoreColors : this.ignoreColors;
-        compareOptions.ignoreRectangles = 'ignoreRectangles' in compareOptions ? compareOptions.ignoreRectangles.push(ignoreRectangles) : ignoreRectangles;
+        compareOptions.ignoreRectangles = 'ignoreRectangles' in compareOptions ? compareOptions.ignoreRectangles.concat(ignoreRectangles) : ignoreRectangles;
         compareOptions.ignoreTransparentPixel = 'ignoreTransparentPixel' in compareOptions ? compareOptions.ignoreTransparentPixel : this.ignoreTransparentPixel;
 
         if (this._isMobile() && ((this.nativeWebScreenshot && compareOptions.isScreen) || (this._isIOS())) && blockOutStatusBar) {


### PR DESCRIPTION
In our testing setup, we encounter an error when running multiple tests with the same options object.

We get an error on this line:
https://github.com/wswebcreation/protractor-image-comparison/blob/6fa7b194b1bb1d6ba37946af51b4252170185ed4/index.js#L354

The error states that 'push is not a function', this is because we encountered compareOptions.ignoreRectangles to be the number 1, rather than an array.

The problem lies in the fact that `.push` is used improperly. From the MDN docs:
> The push() method adds one or more elements to the end of an array and returns the new length of the array.

The push method gives back the new array length instead of the array itself.  
Replacing push with concat fixes this bug.

The following code demonstrates the bug:
```javascript
let ignoreRectangles = [];

const compareOptions = {}

function doIt() {
  compareOptions.ignoreRectangles = 'ignoreRectangles' in compareOptions ? compareOptions.ignoreRectangles.push(ignoreRectangles) : ignoreRectangles;
  console.log(compareOptions);
}

doIt();
doIt();
```

```
$ node test.js
{ ignoreRectangles: [] }
{ ignoreRectangles: 1 }
```