### PR TITLE
Enable taking screenshot directly from canvas

### DIFF
--- a/index.js
+++ b/index.js
@@ -1041,12 +1041,14 @@ class protractorImageComparison {
 
         return this._getInstanceData()
             .then(() => {
-                    if(saveOptions.canvasScreenshot)
+                    if(saveOptions.canvasScreenshot) {
                         return element.getWebElement()
                             .then(elem => browser.executeScript((canvas) => canvas.toDataURL('image/png'), elem))
                             .then(dataUrl => dataUrl.split(',')[1]);
-                    else
+                    }
+                    else {
                         return browser.takeScreenshot()
+                    }
                 }
             )
             .then(screenshot => {


### PR DESCRIPTION
Add boolean options.canvasScreenshot to enable taking screenshot directly from canvas (via dataUrl instead of browser.takeScreenshot())
