### PR TITLE
set imageHeight correctly, if screens.length === 1

### DIFF
--- a/index.js
+++ b/index.js
@@ -165,7 +165,9 @@ class protractorImageComparison {
      */
     _saveFullScreenshot(tag, screens) {
         // Calculate total canvas size
-        const imageHeight = screens.reduce((previous, current) => (previous instanceof Buffer ? previous.readUInt32BE(20) : previous) + current.readUInt32BE(20));
+        const imageHeight = screens.reduce(
+            (previous, current) => (previous instanceof Buffer ? previous.readUInt32BE(20) : previous) + current.readUInt32BE(20),
+            screens[0].readUInt32BE(20));
         const imageWidth = screens[0].readUInt32BE(16);
         const imageOutput = PNGJSImage.createImage(imageWidth, imageHeight);
         let offsetY = 0;

--- a/index.js
+++ b/index.js
@@ -165,9 +165,15 @@ class protractorImageComparison {
      */
     _saveFullScreenshot(tag, screens) {
         // Calculate total canvas size
-        const imageHeight = screens.reduce(
-            (previous, current) => (previous instanceof Buffer ? previous.readUInt32BE(20) : previous) + current.readUInt32BE(20),
-            screens[0].readUInt32BE(20));
+        let imageHeight;
+
+        if (screens.length > 1) {
+            imageHeight = screens.reduce(
+                (previous, current) => (previous instanceof Buffer ? previous.readUInt32BE(20) : previous) + current.readUInt32BE(20));
+        } else {
+            imageHeight = screens[0].readUInt32BE(20);
+        }
+
         const imageWidth = screens[0].readUInt32BE(16);
         const imageOutput = PNGJSImage.createImage(imageWidth, imageHeight);
         let offsetY = 0;


### PR DESCRIPTION
I could reproduce Issue 44 Argument should be a buffer.
In my case, it happened in headless Chrome. I found that this issue happens, if _saveFullScreenshot is called with screens.length === 1. I fixed this by setting the inital value to from screens[0]