### PR TITLE
added tolerance property that prevents saving result image to diff

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -85,6 +85,7 @@ protractorImageComparison
 | options.ignoreTransparentPixel | <code>boolean</code> | Will ignore all pixels that have some transparency in one of the images |
 | options.androidOffsets | <code>object</code> | Object that will hold custom values for the statusBar, addressBar, addressBarScrolled and toolBar |
 | options.iosOffsets | <code>object</code> | Object that will hold the custom values for the statusBar, addressBar, addressBarScrolled and toolBar |
+| options.tolerance | <code>double</code> | Allowable percentage of mismatches |
 
 <a name="checkElement"></a>
 
@@ -105,6 +106,7 @@ Runs the comparison against an element
 | options.ignoreAntialiasing | <code>boolean</code> | compare images an discard anti aliasing |
 | options.ignoreColors | <code>boolean</code> | Even though the images are in colour, the comparison wil compare 2 black/white images |
 | options.ignoreTransparentPixel | <code>boolean</code> | Will ignore all pixels that have some transparency in one of the images |
+| options.tolerance | <code>double</code> | Allowable percentage of mismatches |
 
 **Example**  
 ```js
@@ -123,6 +125,8 @@ browser.protractorImageComparison.checkElement(element(By.id('elementId')), 'ima
 browser.protractorImageComparison.checkElement(element(By.id('elementId')), 'imageA', {ignoreColors: true});
 // Ignore alpha pixel
 browser.protractorImageComparison.checkElement(element(By.id('elementId')), 'imageA', {ignoreTransparentPixel: true});
+// Set tolerance example
+browser.protractorImageComparison.checkElement(element(By.id('elementId')), 'imageA', {tolerance: 0.3});
 ```
 <a name="checkFullPageScreen"></a>
 
@@ -141,6 +145,7 @@ Runs the comparison against the fullpage screenshot
 | options.blockOut | <code>object</code> | blockout with x, y, width and height values |
 | options.disableCSSAnimation | <code>boolean</code> | enable or disable CSS animation |
 | options.fullPageScrollTimeout | <code>int</code> | The time that needs to be waited when scrolling to a point and save the screenshot |
+| options.tolerance | <code>double</code> | Allowable percentage of mismatches |
 
 **Example**  
 ```js
@@ -160,6 +165,8 @@ browser.protractorImageComparison.checkFullPageScreen('imageA', {ignoreAntialias
 browser.protractorImageComparison.checkFullPageScreen('imageA', {ignoreColors: true});
 // Ignore alpha pixel
 browser.protractorImageComparison.checkFullPageScreen('imageA', {ignoreTransparentPixel: true});
+// Allowable percentage of mismatches
+browser.protractorImageComparison.checkFullPageScreen('imageA', {tolerance: 0.5});
 ```
 <a name="checkScreen"></a>
 
@@ -180,6 +187,7 @@ Runs the comparison against the screen
 | options.ignoreAntialiasing | <code>boolean</code> | compare images an discard anti aliasing |
 | options.ignoreColors | <code>boolean</code> | Even though the images are in colour, the comparison wil compare 2 black/white images |
 | options.ignoreTransparentPixel | <code>boolean</code> | Will ignore all pixels that have some transparency in one of the images |
+| options.tolerance | <code>double</code> | Allowable percentage of mismatches |
 
 **Example**  
 ```js
@@ -197,6 +205,8 @@ browser.protractorImageComparison.checkScreen('imageA', {ignoreAntialiasing: tru
 browser.protractorImageComparison.checkScreen('imageA', {ignoreColors: true});
 // Ignore alpha pixel
 browser.protractorImageComparison.checkScreen('imageA', {ignoreTransparentPixel: true});
+// Allowable percentage of mismatches
+browser.protractorImageComparison.checkScreen('imageA', {tolerance: 0.5});
 ```
 <a name="saveElement"></a>
 

--- a/docs/methods.md
+++ b/docs/methods.md
@@ -46,6 +46,7 @@ Code details and example usage can be found [here](./index.md).
 * `ignoreColors` Even though the images are in colour, the comparison will compare 2 black/white images (default: false). *Remark: `ignoreColors: true` will automatically defaulted to `false` if `ignoreAntialiasing: true`*. Can also be set per testcase, see [here](./index.md)
 * `ignoreTransparentPixel` Will ignore all pixels that have some transparency in one of the images. With this flag `true` you can blockout regions by making them transparent in the base image.
 * `iosOffsets` An object that will hold the pixels of the `statusBar` and or the `addressBar`. The values are used to calculate the position of an element on a screen (for `saveElement` or `checkElement`). They are defaulted, but can be overridden. These values can be different per iOS version. Look up the docs for developing for iOS to see the values. If not provided the defaults will be used.
+* `tolerance` Value that defines allowable percentage of mismatches between images. In case when mismatches value less than tolerance, image with comparison results will no be saved into "diff" folder. If not provided default value will be used.
 
 **For example:**
 
@@ -66,7 +67,8 @@ browser.protractorImageComparison = new protractorImageComparison({
 		statusBar: 40,
 		addressBar: 100
 	},
-	ignoreAntialiasing: true
+	ignoreAntialiasing: true,
+  tolerance: 0.5
 });
 `````
 

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ const resembleJS = require('./lib/resemble');
  * @param {boolean} options.ignoreTransparentPixel Will ignore all pixels that have some transparency in one of the images
  * @param {object} options.androidOffsets Object that will hold custom values for the statusBar, addressBar, addressBarScrolled and toolBar
  * @param {object} options.iosOffsets Object that will hold the custom values for the statusBar, addressBar, addressBarScrolled and toolBar
+ * @param {number} options.tolerance Allowable value of misMatchPercentage that prevents saving image with differences
  *
  * @property {string} actualFolder Path where the actual screenshots are saved
  * @property {number} addressBarShadowPadding Mobile Chrome and mobile Safari have a shadow below the addressbar, this property will make sure that it wont be seen in the image
@@ -74,6 +75,8 @@ class protractorImageComparison {
         this.ignoreAntialiasing = options.ignoreAntialiasing || false;
         this.ignoreColors = options.ignoreColors || false;
         this.ignoreTransparentPixel = options.ignoreTransparentPixel || false;
+
+        this.tolerance = options.tolerance || 0;
 
         // OS offsets
         let androidOffsets = options.androidOffsets && typeof options.androidOffsets === 'object' ? options.androidOffsets : {};
@@ -348,6 +351,7 @@ class protractorImageComparison {
      * @param {boolean} compareOptions.ignoreAntialiasing compare images an discard anti aliasing
      * @param {boolean} compareOptions.ignoreColors Even though the images are in colour, the comparison wil compare 2 black/white images
      * @param {boolean} compareOptions.ignoreTransparentPixel Will ignore all pixels that have some transparency in one of the images
+     * @param {number} compareOptions.tolerance Allowable value of misMatchPercentage that prevents saving image with differences
      * @returns {Promise}
      * @private
      */
@@ -355,6 +359,7 @@ class protractorImageComparison {
         const imageComparisonPaths = this._determineImageComparisonPaths(tag);
         const ignoreRectangles = 'blockOut' in compareOptions ? compareOptions.blockOut : [];
         const blockOutStatusBar = compareOptions.blockOutStatusBar || compareOptions.blockOutStatusBar === false ? compareOptions.blockOutStatusBar : this.blockOutStatusBar;
+        const tolerance = compareOptions.tolerance || this.tolerance;
 
         // comparison options are not available anymore, due to new version and api
         compareOptions.ignoreAntialiasing = 'ignoreAntialiasing' in compareOptions ? compareOptions.ignoreAntialiasing : this.ignoreAntialiasing;
@@ -383,7 +388,7 @@ class protractorImageComparison {
         return new Promise(resolve => {
             resembleJS(imageComparisonPaths.baselineImage, imageComparisonPaths.actualImage, compareOptions)
                 .onComplete(data => {
-                    if (Number(data.misMatchPercentage) > 0 || this.debug) {
+                    if (Number(data.misMatchPercentage) > tolerance || this.debug) {
                         data.getDiffImage().pack().pipe(fs.createWriteStream(imageComparisonPaths.imageDiffPath));
                     }
                     resolve(Number(data.misMatchPercentage));
@@ -955,6 +960,8 @@ class protractorImageComparison {
      * browser.protractorImageComparison.checkFullPageScreen('imageA', {ignoreColors: true});
      * // Ignore alpha pixel
      * browser.protractorImageComparison.checkFullPageScreen('imageA', {ignoreTransparentPixel: true});
+     * // Set allowable percentage of mismatches
+     * browser.protractorImageComparison.checkFullPageScreen('imageA', {tolerance: 0.5});
      *
      * @param {string} tag The tag that is used
      * @param {object} options (non-default) options
@@ -962,6 +969,7 @@ class protractorImageComparison {
      * @param {object} options.blockOut blockout with x, y, width and height values
      * @param {boolean} options.disableCSSAnimation enable or disable CSS animation
      * @param {int} options.fullPageScrollTimeout The time that needs to be waited when scrolling to a point and save the screenshot
+     * @param {double} options.tolerance Allowable percentage of mismatches
      * @return {Promise} When the promise is resolved it will return the percentage of the difference
      * @public
      */


### PR DESCRIPTION
This is implementation of [feature](https://github.com/wswebcreation/protractor-image-comparison/issues/51) request for tolerance property that allows to set allowable percentage of mismatches and don't save image with comparison results to diff folder.