### PR TITLE
Fix ubuntu issue 68

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The comparison methods return a result in percentages like `0` or `3.94`, or whe
 
 More information about the **methods** can be found [here](./docs/methods.md).
 
-## Ouput
+## Output
 To see example of the output please check [here](./docs/output.md)
 
 ## Conventions

--- a/lib/resemble.js
+++ b/lib/resemble.js
@@ -35,7 +35,7 @@ URL: https://github.com/Huddle/Resemble.js
       : {
         createElement: function () {
           // This will work as long as only createElement is used on window.document
-          return new Canvas();
+          return Canvas.createCanvas();
         }
       };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "protractor-image-comparison",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -28,8 +28,8 @@
       "integrity": "sha512-3Sp6WZZ/lXl+nTDoGpGWHEpTnnC6X5fnkolYZR6nwIfzbxxvA8utPWe1gCt7i0m9uVGsSz2IS8K8mJ7HmlduMg==",
       "dev": true,
       "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
       }
     },
     "abbrev": {
@@ -49,7 +49,7 @@
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0"
+        "acorn": "^3.0.4"
       }
     },
     "adm-zip": {
@@ -64,7 +64,7 @@
       "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
       "dev": true,
       "requires": {
-        "es6-promisify": "5.0.0"
+        "es6-promisify": "^5.0.0"
       }
     },
     "ajv": {
@@ -72,8 +72,8 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
       "requires": {
-        "co": "4.6.0",
-        "json-stable-stringify": "1.0.1"
+        "co": "^4.6.0",
+        "json-stable-stringify": "^1.0.1"
       }
     },
     "align-text": {
@@ -82,9 +82,9 @@
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "amdefine": {
@@ -99,7 +99,7 @@
       "integrity": "sha1-HBg5S2r5t2/5pjUJ+kl2af0s5T4=",
       "dev": true,
       "requires": {
-        "array-back": "1.0.4"
+        "array-back": "^1.0.3"
       }
     },
     "ansi-regex": {
@@ -119,12 +119,12 @@
       "integrity": "sha1-l+ubibVnj6LdyXk7EphijMIYQp8=",
       "dev": true,
       "requires": {
-        "array-back": "1.0.4",
-        "core-js": "2.5.7",
-        "feature-detect-es6": "1.4.1",
-        "home-path": "1.0.6",
-        "test-value": "2.1.0",
-        "usage-stats": "0.8.6"
+        "array-back": "^1.0.4",
+        "core-js": "^2.4.1",
+        "feature-detect-es6": "^1.3.1",
+        "home-path": "^1.0.3",
+        "test-value": "^2.1.0",
+        "usage-stats": "^0.8.2"
       }
     },
     "aproba": {
@@ -137,8 +137,8 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.6"
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       }
     },
     "argparse": {
@@ -147,7 +147,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "array-back": {
@@ -156,7 +156,7 @@
       "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
       "dev": true,
       "requires": {
-        "typical": "2.6.1"
+        "typical": "^2.6.0"
       }
     },
     "array-find-index": {
@@ -177,7 +177,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -242,9 +242,9 @@
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.7",
-        "regenerator-runtime": "0.10.5"
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
       }
     },
     "babel-runtime": {
@@ -253,8 +253,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.7",
-        "regenerator-runtime": "0.11.1"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       },
       "dependencies": {
         "regenerator-runtime": {
@@ -276,15 +276,7 @@
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
-      }
-    },
-    "block-stream": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-      "requires": {
-        "inherits": "2.0.1"
+        "tweetnacl": "^0.14.3"
       }
     },
     "blocking-proxy": {
@@ -293,7 +285,7 @@
       "integrity": "sha512-KE8NFMZr3mN2E0HcvCgRtX7DjhiIQrwle+nSVJVC/yqFb9+xznHl2ZcoBp2L9qzkI4t4cBFJ1efXF8Dwi132RA==",
       "dev": true,
       "requires": {
-        "minimist": "1.2.0"
+        "minimist": "^1.2.0"
       },
       "dependencies": {
         "minimist": {
@@ -315,7 +307,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "2.x.x"
       }
     },
     "brace-expansion": {
@@ -323,7 +315,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -339,11 +331,11 @@
       "integrity": "sha1-FS21Asa7I7WqP2Y+Iw1d6OxOTz8=",
       "dev": true,
       "requires": {
-        "array-back": "1.0.4",
-        "core-js": "2.5.7",
-        "feature-detect-es6": "1.4.1",
-        "fs-then-native": "1.0.2",
-        "mkdirp": "0.5.1"
+        "array-back": "^1.0.3",
+        "core-js": "^2.4.1",
+        "feature-detect-es6": "^1.3.1",
+        "fs-then-native": "^1.0.2",
+        "mkdirp": "~0.5.1"
       }
     },
     "camel-case": {
@@ -351,8 +343,8 @@
       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
       "requires": {
-        "no-case": "2.3.2",
-        "upper-case": "1.1.3"
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.1"
       }
     },
     "camelcase": {
@@ -367,18 +359,18 @@
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "2.1.1",
-        "map-obj": "1.0.1"
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
       }
     },
     "canvas-prebuilt": {
-      "version": "1.6.5-prerelease.1",
-      "resolved": "https://registry.npmjs.org/canvas-prebuilt/-/canvas-prebuilt-1.6.5-prerelease.1.tgz",
-      "integrity": "sha1-aBSyC5yAg13MJL/WGZFHKIYwUhw=",
+      "version": "2.0.0-alpha.14",
+      "resolved": "https://registry.npmjs.org/canvas-prebuilt/-/canvas-prebuilt-2.0.0-alpha.14.tgz",
+      "integrity": "sha512-b4QydUnFNxpgctSbHnJWsCDaqtq2AMYa9/B7q4+cGnBrEtMIcLcXpKltT/iSB39AHOTDIprYeHuvyy3h2k1ltg==",
       "requires": {
-        "node-pre-gyp": "0.6.39",
-        "parse-css-font": "2.0.2",
-        "units-css": "0.4.0"
+        "detect-libc": "^1.0.3",
+        "nan": "^2.9.2",
+        "node-pre-gyp": "^0.10.0"
       }
     },
     "caseless": {
@@ -392,7 +384,7 @@
       "integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
       "dev": true,
       "requires": {
-        "underscore-contrib": "0.3.0"
+        "underscore-contrib": "~0.3.0"
       }
     },
     "center-align": {
@@ -402,8 +394,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chalk": {
@@ -412,12 +404,17 @@
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
+    },
+    "chownr": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
     },
     "ci-info": {
       "version": "1.1.3",
@@ -431,10 +428,10 @@
       "integrity": "sha1-xXysxAa7z57iFkZgcWHtQy71oFo=",
       "dev": true,
       "requires": {
-        "ansi-escape-sequences": "3.0.0",
-        "command-line-args": "3.0.5",
-        "command-line-commands": "1.0.4",
-        "command-line-usage": "3.0.8"
+        "ansi-escape-sequences": "^3.0.0",
+        "command-line-args": "^3.0.1",
+        "command-line-commands": "^1.0.4",
+        "command-line-usage": "^3.0.5"
       }
     },
     "cliui": {
@@ -444,8 +441,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
       },
       "dependencies": {
@@ -474,8 +471,8 @@
       "integrity": "sha512-0y0rBgoX8IzIjBAUnO73SEtSb4Mhk3IoceWJq5zZSxb9mWORhWH8xLYo4EDSOE1jRBk1LhmfjqWFFt10h/+MEA==",
       "dev": true,
       "requires": {
-        "stream-connect": "1.0.2",
-        "stream-via": "1.0.4"
+        "stream-connect": "^1.0.2",
+        "stream-via": "^1.0.4"
       }
     },
     "colors": {
@@ -489,7 +486,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "command-line-args": {
@@ -498,10 +495,10 @@
       "integrity": "sha1-W9StReeYPlwTRJGOQCgO4mk8WsA=",
       "dev": true,
       "requires": {
-        "array-back": "1.0.4",
-        "feature-detect-es6": "1.4.1",
-        "find-replace": "1.0.3",
-        "typical": "2.6.1"
+        "array-back": "^1.0.4",
+        "feature-detect-es6": "^1.3.1",
+        "find-replace": "^1.0.2",
+        "typical": "^2.6.0"
       }
     },
     "command-line-commands": {
@@ -510,8 +507,8 @@
       "integrity": "sha1-A0+bFntRiK+9z2su+7FQ/IRCwys=",
       "dev": true,
       "requires": {
-        "array-back": "1.0.4",
-        "feature-detect-es6": "1.4.1"
+        "array-back": "^1.0.3",
+        "feature-detect-es6": "^1.3.1"
       }
     },
     "command-line-tool": {
@@ -520,12 +517,12 @@
       "integrity": "sha1-TBHjcvPkElSGHD/mtTjTx6WxRPM=",
       "dev": true,
       "requires": {
-        "ansi-escape-sequences": "3.0.0",
-        "array-back": "1.0.4",
-        "command-line-args": "3.0.5",
-        "command-line-usage": "3.0.8",
-        "feature-detect-es6": "1.4.1",
-        "typical": "2.6.1"
+        "ansi-escape-sequences": "^3.0.0",
+        "array-back": "^1.0.3",
+        "command-line-args": "^3.0.1",
+        "command-line-usage": "^3.0.3",
+        "feature-detect-es6": "^1.3.1",
+        "typical": "^2.6.0"
       }
     },
     "command-line-usage": {
@@ -534,11 +531,11 @@
       "integrity": "sha1-tqIJeMGzg0d/XBGlKUKLiAv+D00=",
       "dev": true,
       "requires": {
-        "ansi-escape-sequences": "3.0.0",
-        "array-back": "1.0.4",
-        "feature-detect-es6": "1.4.1",
-        "table-layout": "0.3.0",
-        "typical": "2.6.1"
+        "ansi-escape-sequences": "^3.0.0",
+        "array-back": "^1.0.3",
+        "feature-detect-es6": "^1.3.1",
+        "table-layout": "^0.3.0",
+        "typical": "^2.6.0"
       }
     },
     "commander": {
@@ -547,7 +544,7 @@
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
       "dev": true,
       "requires": {
-        "graceful-readlink": "1.0.1"
+        "graceful-readlink": ">= 1.0.0"
       }
     },
     "common-sequence": {
@@ -562,8 +559,8 @@
       "integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
       "dev": true,
       "requires": {
-        "array-ify": "1.0.0",
-        "dot-prop": "3.0.0"
+        "array-ify": "^1.0.0",
+        "dot-prop": "^3.0.0"
       }
     },
     "concat-map": {
@@ -577,9 +574,9 @@
       "integrity": "sha1-50lQXF0/lG8vrTx23+cfymiXUdw=",
       "dev": true,
       "requires": {
-        "babel-polyfill": "6.26.0",
-        "feature-detect-es6": "1.4.1",
-        "walk-back": "2.0.1"
+        "babel-polyfill": "^6.13.0",
+        "feature-detect-es6": "^1.3.1",
+        "walk-back": "^2.0.1"
       }
     },
     "console-control-strings": {
@@ -593,16 +590,16 @@
       "integrity": "sha1-iuP7Wf63S77golgz7h+D2tSgeHQ=",
       "dev": true,
       "requires": {
-        "conventional-changelog-angular": "1.6.6",
-        "conventional-changelog-atom": "0.1.2",
-        "conventional-changelog-codemirror": "0.1.0",
-        "conventional-changelog-core": "1.9.5",
-        "conventional-changelog-ember": "0.2.10",
-        "conventional-changelog-eslint": "0.1.0",
-        "conventional-changelog-express": "0.1.0",
-        "conventional-changelog-jquery": "0.1.0",
-        "conventional-changelog-jscs": "0.1.0",
-        "conventional-changelog-jshint": "0.1.0"
+        "conventional-changelog-angular": "^1.0.0",
+        "conventional-changelog-atom": "^0.1.0",
+        "conventional-changelog-codemirror": "^0.1.0",
+        "conventional-changelog-core": "^1.3.0",
+        "conventional-changelog-ember": "^0.2.0",
+        "conventional-changelog-eslint": "^0.1.0",
+        "conventional-changelog-express": "^0.1.0",
+        "conventional-changelog-jquery": "^0.1.0",
+        "conventional-changelog-jscs": "^0.1.0",
+        "conventional-changelog-jshint": "^0.1.0"
       }
     },
     "conventional-changelog-angular": {
@@ -611,8 +608,8 @@
       "integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
       "dev": true,
       "requires": {
-        "compare-func": "1.3.2",
-        "q": "1.5.1"
+        "compare-func": "^1.3.1",
+        "q": "^1.5.1"
       }
     },
     "conventional-changelog-atom": {
@@ -621,7 +618,7 @@
       "integrity": "sha1-Ella1SZ6aTfDTPkAKBscZRmKTGM=",
       "dev": true,
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.4.1"
       }
     },
     "conventional-changelog-codemirror": {
@@ -630,7 +627,7 @@
       "integrity": "sha1-dXelkdv5tTjnoVCn7mL2WihyszQ=",
       "dev": true,
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.4.1"
       }
     },
     "conventional-changelog-core": {
@@ -639,19 +636,19 @@
       "integrity": "sha1-XbdWba18DLddr0f7spdve/mSjB0=",
       "dev": true,
       "requires": {
-        "conventional-changelog-writer": "2.0.3",
-        "conventional-commits-parser": "2.1.7",
-        "dateformat": "1.0.12",
-        "get-pkg-repo": "1.4.0",
-        "git-raw-commits": "1.3.6",
-        "git-remote-origin-url": "2.0.0",
-        "git-semver-tags": "1.3.6",
-        "lodash": "4.17.10",
-        "normalize-package-data": "2.4.0",
-        "q": "1.5.1",
-        "read-pkg": "1.1.0",
-        "read-pkg-up": "1.0.1",
-        "through2": "2.0.3"
+        "conventional-changelog-writer": "^2.0.3",
+        "conventional-commits-parser": "^2.1.0",
+        "dateformat": "^1.0.12",
+        "get-pkg-repo": "^1.0.0",
+        "git-raw-commits": "^1.3.0",
+        "git-remote-origin-url": "^2.0.0",
+        "git-semver-tags": "^1.2.3",
+        "lodash": "^4.0.0",
+        "normalize-package-data": "^2.3.5",
+        "q": "^1.4.1",
+        "read-pkg": "^1.1.0",
+        "read-pkg-up": "^1.0.1",
+        "through2": "^2.0.0"
       }
     },
     "conventional-changelog-ember": {
@@ -660,7 +657,7 @@
       "integrity": "sha512-LBBBZO6Q7ib4HhSdyCNVR25OtaXl710UJg1aSHCLmR8AjuXKs3BO8tnbY1MH+D1C+z5IFoEDkpjOddefNTyhCQ==",
       "dev": true,
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.4.1"
       }
     },
     "conventional-changelog-eslint": {
@@ -669,7 +666,7 @@
       "integrity": "sha1-pSQR6ZngUBzlALhWsKZD0DMJB+I=",
       "dev": true,
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.4.1"
       }
     },
     "conventional-changelog-express": {
@@ -678,7 +675,7 @@
       "integrity": "sha1-VcbIQcgRliA2wDe9vZZKVK4xD84=",
       "dev": true,
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.4.1"
       }
     },
     "conventional-changelog-jquery": {
@@ -687,7 +684,7 @@
       "integrity": "sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=",
       "dev": true,
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.4.1"
       }
     },
     "conventional-changelog-jscs": {
@@ -696,7 +693,7 @@
       "integrity": "sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=",
       "dev": true,
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.4.1"
       }
     },
     "conventional-changelog-jshint": {
@@ -705,8 +702,8 @@
       "integrity": "sha1-AMq46aMxdIer2UxNhGcTQpGNKgc=",
       "dev": true,
       "requires": {
-        "compare-func": "1.3.2",
-        "q": "1.5.1"
+        "compare-func": "^1.3.1",
+        "q": "^1.4.1"
       }
     },
     "conventional-changelog-writer": {
@@ -715,16 +712,16 @@
       "integrity": "sha512-2E1h7UXL0fhRO5h0CxDZ5EBc5sfBZEQePvuZ+gPvApiRrICUyNDy/NQIP+2TBd4wKZQf2Zm7TxbzXHG5HkPIbA==",
       "dev": true,
       "requires": {
-        "compare-func": "1.3.2",
-        "conventional-commits-filter": "1.1.6",
-        "dateformat": "1.0.12",
-        "handlebars": "4.0.11",
-        "json-stringify-safe": "5.0.1",
-        "lodash": "4.17.10",
-        "meow": "3.7.0",
-        "semver": "5.5.0",
-        "split": "1.0.1",
-        "through2": "2.0.3"
+        "compare-func": "^1.3.1",
+        "conventional-commits-filter": "^1.1.1",
+        "dateformat": "^1.0.11",
+        "handlebars": "^4.0.2",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.0.0",
+        "meow": "^3.3.0",
+        "semver": "^5.0.1",
+        "split": "^1.0.0",
+        "through2": "^2.0.0"
       }
     },
     "conventional-commit-types": {
@@ -739,8 +736,8 @@
       "integrity": "sha512-KcDgtCRKJCQhyk6VLT7zR+ZOyCnerfemE/CsR3iQpzRRFbLEs0Y6rwk3mpDvtOh04X223z+1xyJ582Stfct/0Q==",
       "dev": true,
       "requires": {
-        "is-subset": "0.1.1",
-        "modify-values": "1.0.1"
+        "is-subset": "^0.1.1",
+        "modify-values": "^1.0.0"
       }
     },
     "conventional-commits-parser": {
@@ -749,13 +746,13 @@
       "integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.3",
-        "is-text-path": "1.0.1",
-        "lodash": "4.17.10",
-        "meow": "4.0.1",
-        "split2": "2.2.0",
-        "through2": "2.0.3",
-        "trim-off-newlines": "1.0.1"
+        "JSONStream": "^1.0.4",
+        "is-text-path": "^1.0.0",
+        "lodash": "^4.2.1",
+        "meow": "^4.0.0",
+        "split2": "^2.0.0",
+        "through2": "^2.0.0",
+        "trim-off-newlines": "^1.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -770,9 +767,9 @@
           "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0",
-            "map-obj": "2.0.0",
-            "quick-lru": "1.1.0"
+            "camelcase": "^4.1.0",
+            "map-obj": "^2.0.0",
+            "quick-lru": "^1.0.0"
           }
         },
         "find-up": {
@@ -781,7 +778,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         },
         "indent-string": {
@@ -796,10 +793,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "4.0.0",
-            "pify": "3.0.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "map-obj": {
@@ -814,15 +811,15 @@
           "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
           "dev": true,
           "requires": {
-            "camelcase-keys": "4.2.0",
-            "decamelize-keys": "1.1.0",
-            "loud-rejection": "1.6.0",
-            "minimist": "1.2.0",
-            "minimist-options": "3.0.2",
-            "normalize-package-data": "2.4.0",
-            "read-pkg-up": "3.0.0",
-            "redent": "2.0.0",
-            "trim-newlines": "2.0.0"
+            "camelcase-keys": "^4.0.0",
+            "decamelize-keys": "^1.0.0",
+            "loud-rejection": "^1.0.0",
+            "minimist": "^1.1.3",
+            "minimist-options": "^3.0.1",
+            "normalize-package-data": "^2.3.4",
+            "read-pkg-up": "^3.0.0",
+            "redent": "^2.0.0",
+            "trim-newlines": "^2.0.0"
           }
         },
         "minimist": {
@@ -837,8 +834,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.1",
-            "json-parse-better-errors": "1.0.2"
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
           }
         },
         "path-type": {
@@ -847,7 +844,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "3.0.0"
+            "pify": "^3.0.0"
           }
         },
         "pify": {
@@ -862,9 +859,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "4.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "3.0.0"
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
           }
         },
         "read-pkg-up": {
@@ -873,8 +870,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "3.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
           }
         },
         "redent": {
@@ -883,8 +880,8 @@
           "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
           "dev": true,
           "requires": {
-            "indent-string": "3.2.0",
-            "strip-indent": "2.0.0"
+            "indent-string": "^3.0.0",
+            "strip-indent": "^2.0.0"
           }
         },
         "strip-bom": {
@@ -923,46 +920,8 @@
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
       "requires": {
-        "boom": "2.10.1"
+        "boom": "2.x.x"
       }
-    },
-    "css-font-size-keywords": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-font-size-keywords/-/css-font-size-keywords-1.0.0.tgz",
-      "integrity": "sha1-hUh1rOmspqjS7g00WkSq6btttss="
-    },
-    "css-font-stretch-keywords": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/css-font-stretch-keywords/-/css-font-stretch-keywords-1.0.1.tgz",
-      "integrity": "sha1-UM7puboDH7XJUtRyMTnx4Qe1SxA="
-    },
-    "css-font-style-keywords": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/css-font-style-keywords/-/css-font-style-keywords-1.0.1.tgz",
-      "integrity": "sha1-XDUygT9jtKHelU0TzqhqtDM0CeQ="
-    },
-    "css-font-weight-keywords": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-font-weight-keywords/-/css-font-weight-keywords-1.0.0.tgz",
-      "integrity": "sha1-m8BGcayFvHJLV07106yWsNYE/Zc="
-    },
-    "css-global-keywords": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/css-global-keywords/-/css-global-keywords-1.0.1.tgz",
-      "integrity": "sha1-cqmupyeW0Bmx0qMlLeTlqqN+Smk="
-    },
-    "css-list-helpers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/css-list-helpers/-/css-list-helpers-1.0.1.tgz",
-      "integrity": "sha1-//VxkiAtuDJAxBaG+RnkSacCT30=",
-      "requires": {
-        "tcomb": "2.7.0"
-      }
-    },
-    "css-system-font-keywords": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-system-font-keywords/-/css-system-font-keywords-1.0.0.tgz",
-      "integrity": "sha1-hcbwhquk6zLFcaMIav/ENLhII+0="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -970,7 +929,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "1.0.2"
+        "array-find-index": "^1.0.1"
       }
     },
     "dargs": {
@@ -979,7 +938,7 @@
       "integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "dashdash": {
@@ -987,7 +946,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -1003,8 +962,8 @@
       "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1",
-        "meow": "3.7.0"
+        "get-stdin": "^4.0.1",
+        "meow": "^3.3.0"
       }
     },
     "debug": {
@@ -1027,8 +986,8 @@
       "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
       "dev": true,
       "requires": {
-        "decamelize": "1.2.0",
-        "map-obj": "1.0.1"
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
       }
     },
     "deep-extend": {
@@ -1054,13 +1013,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.1",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "delayed-stream": {
@@ -1084,19 +1043,19 @@
       "integrity": "sha1-dL6N5tbqeNBLEUF9bGvy8dM+xoY=",
       "dev": true,
       "requires": {
-        "array-back": "1.0.4",
-        "cache-point": "0.3.4",
-        "common-sequence": "1.0.2",
-        "core-js": "2.5.7",
-        "file-set": "1.1.1",
+        "array-back": "^1.0.3",
+        "cache-point": "^0.3.4",
+        "common-sequence": "^1.0.2",
+        "core-js": "^2.4.1",
+        "file-set": "^1.1.1",
         "handlebars": "3.0.3",
-        "marked": "0.3.19",
-        "object-get": "2.1.0",
-        "reduce-flatten": "1.0.1",
-        "reduce-unique": "1.0.0",
-        "reduce-without": "1.0.1",
-        "test-value": "2.1.0",
-        "walk-back": "2.0.1"
+        "marked": "^0.3.6",
+        "object-get": "^2.1.0",
+        "reduce-flatten": "^1.0.1",
+        "reduce-unique": "^1.0.0",
+        "reduce-without": "^1.0.1",
+        "test-value": "^2.1.0",
+        "walk-back": "^2.0.1"
       },
       "dependencies": {
         "async": {
@@ -1112,9 +1071,9 @@
           "integrity": "sha1-DgllGi8Ps8lJFgWDcQ1VH5Lm0q0=",
           "dev": true,
           "requires": {
-            "optimist": "0.6.1",
-            "source-map": "0.1.43",
-            "uglify-js": "2.3.6"
+            "optimist": "^0.6.1",
+            "source-map": "^0.1.40",
+            "uglify-js": "~2.3"
           }
         },
         "source-map": {
@@ -1123,7 +1082,7 @@
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         },
         "uglify-js": {
@@ -1133,9 +1092,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "async": "0.2.10",
-            "optimist": "0.3.7",
-            "source-map": "0.1.43"
+            "async": "~0.2.6",
+            "optimist": "~0.3.5",
+            "source-map": "~0.1.7"
           },
           "dependencies": {
             "optimist": {
@@ -1145,7 +1104,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "wordwrap": "0.0.3"
+                "wordwrap": "~0.0.2"
               }
             }
           }
@@ -1158,7 +1117,7 @@
       "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
       "dev": true,
       "requires": {
-        "is-obj": "1.0.1"
+        "is-obj": "^1.0.0"
       }
     },
     "ecc-jsbn": {
@@ -1167,7 +1126,7 @@
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "error-ex": {
@@ -1176,7 +1135,7 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es6-promise": {
@@ -1191,7 +1150,7 @@
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
-        "es6-promise": "4.2.4"
+        "es6-promise": "^4.0.3"
       }
     },
     "escape-string-regexp": {
@@ -1206,11 +1165,11 @@
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
       "dev": true,
       "requires": {
-        "esprima": "2.7.3",
-        "estraverse": "1.9.3",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.2.0"
+        "esprima": "^2.7.1",
+        "estraverse": "^1.9.1",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.2.0"
       },
       "dependencies": {
         "source-map": {
@@ -1220,7 +1179,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -1231,8 +1190,8 @@
       "integrity": "sha1-/V3ux2qXpRIKnNOnyxF3oJI7EdI=",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0",
-        "acorn-jsx": "3.0.1"
+        "acorn": "^3.3.0",
+        "acorn-jsx": "^3.0.0"
       }
     },
     "esprima": {
@@ -1281,7 +1240,7 @@
       "integrity": "sha512-iMxKpKdIBgcWiBPtz2qnEsNjCE2dBQvDyUqgrXLJboiaHwJa+2vDIZ8XbgNZGh1Rx1PUfZmI7uhG6Z4iQYWVjg==",
       "dev": true,
       "requires": {
-        "array-back": "1.0.4"
+        "array-back": "^1.0.4"
       }
     },
     "file-set": {
@@ -1290,8 +1249,8 @@
       "integrity": "sha1-0+xwwIDsjxjyBLod4QZ4DJBWkms=",
       "dev": true,
       "requires": {
-        "array-back": "1.0.4",
-        "glob": "7.1.2"
+        "array-back": "^1.0.3",
+        "glob": "^7.1.0"
       }
     },
     "find-parent-dir": {
@@ -1306,8 +1265,8 @@
       "integrity": "sha1-uI5zZNLZyVlVnziMZmcNYTBEH6A=",
       "dev": true,
       "requires": {
-        "array-back": "1.0.4",
-        "test-value": "2.1.0"
+        "array-back": "^1.0.4",
+        "test-value": "^2.1.0"
       }
     },
     "find-up": {
@@ -1316,8 +1275,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "findup": {
@@ -1326,8 +1285,8 @@
       "integrity": "sha1-itkpozk7rGJ5V6fl3kYjsGsOLOs=",
       "dev": true,
       "requires": {
-        "colors": "0.6.2",
-        "commander": "2.1.0"
+        "colors": "~0.6.0-1",
+        "commander": "~2.1.0"
       },
       "dependencies": {
         "colors": {
@@ -1354,9 +1313,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
       "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.6",
-        "mime-types": "2.1.18"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.5",
+        "mime-types": "^2.1.12"
       }
     },
     "fs-extra": {
@@ -1364,9 +1323,17 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
       "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "2.4.0",
-        "klaw": "1.3.1"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0",
+        "klaw": "^1.0.0"
+      }
+    },
+    "fs-minipass": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+      "requires": {
+        "minipass": "^2.2.1"
       }
     },
     "fs-then-native": {
@@ -1375,7 +1342,7 @@
       "integrity": "sha1-rI04B8nxu9Enlgf7Io4Ktkm7Qf4=",
       "dev": true,
       "requires": {
-        "feature-detect-es6": "1.4.1"
+        "feature-detect-es6": "^1.3.1"
       }
     },
     "fs.realpath": {
@@ -1383,40 +1350,19 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
-    "fstream": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "inherits": "2.0.1",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2"
-      }
-    },
-    "fstream-ignore": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-      "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-      "requires": {
-        "fstream": "1.0.11",
-        "inherits": "2.0.1",
-        "minimatch": "3.0.4"
-      }
-    },
     "gauge": {
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "requires": {
-        "aproba": "1.2.0",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.3"
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
       }
     },
     "get-pkg-repo": {
@@ -1425,11 +1371,11 @@
       "integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.6.0",
-        "meow": "3.7.0",
-        "normalize-package-data": "2.4.0",
-        "parse-github-repo-url": "1.4.1",
-        "through2": "2.0.3"
+        "hosted-git-info": "^2.1.4",
+        "meow": "^3.3.0",
+        "normalize-package-data": "^2.3.0",
+        "parse-github-repo-url": "^1.3.0",
+        "through2": "^2.0.0"
       }
     },
     "get-stdin": {
@@ -1443,7 +1389,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -1459,11 +1405,11 @@
       "integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
       "dev": true,
       "requires": {
-        "dargs": "4.1.0",
-        "lodash.template": "4.4.0",
-        "meow": "4.0.1",
-        "split2": "2.2.0",
-        "through2": "2.0.3"
+        "dargs": "^4.0.1",
+        "lodash.template": "^4.0.2",
+        "meow": "^4.0.0",
+        "split2": "^2.0.0",
+        "through2": "^2.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -1478,9 +1424,9 @@
           "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0",
-            "map-obj": "2.0.0",
-            "quick-lru": "1.1.0"
+            "camelcase": "^4.1.0",
+            "map-obj": "^2.0.0",
+            "quick-lru": "^1.0.0"
           }
         },
         "find-up": {
@@ -1489,7 +1435,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         },
         "indent-string": {
@@ -1504,10 +1450,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "4.0.0",
-            "pify": "3.0.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "map-obj": {
@@ -1522,15 +1468,15 @@
           "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
           "dev": true,
           "requires": {
-            "camelcase-keys": "4.2.0",
-            "decamelize-keys": "1.1.0",
-            "loud-rejection": "1.6.0",
-            "minimist": "1.2.0",
-            "minimist-options": "3.0.2",
-            "normalize-package-data": "2.4.0",
-            "read-pkg-up": "3.0.0",
-            "redent": "2.0.0",
-            "trim-newlines": "2.0.0"
+            "camelcase-keys": "^4.0.0",
+            "decamelize-keys": "^1.0.0",
+            "loud-rejection": "^1.0.0",
+            "minimist": "^1.1.3",
+            "minimist-options": "^3.0.1",
+            "normalize-package-data": "^2.3.4",
+            "read-pkg-up": "^3.0.0",
+            "redent": "^2.0.0",
+            "trim-newlines": "^2.0.0"
           }
         },
         "minimist": {
@@ -1545,8 +1491,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.1",
-            "json-parse-better-errors": "1.0.2"
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
           }
         },
         "path-type": {
@@ -1555,7 +1501,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "3.0.0"
+            "pify": "^3.0.0"
           }
         },
         "pify": {
@@ -1570,9 +1516,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "4.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "3.0.0"
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
           }
         },
         "read-pkg-up": {
@@ -1581,8 +1527,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "3.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
           }
         },
         "redent": {
@@ -1591,8 +1537,8 @@
           "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
           "dev": true,
           "requires": {
-            "indent-string": "3.2.0",
-            "strip-indent": "2.0.0"
+            "indent-string": "^3.0.0",
+            "strip-indent": "^2.0.0"
           }
         },
         "strip-bom": {
@@ -1621,8 +1567,8 @@
       "integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
       "dev": true,
       "requires": {
-        "gitconfiglocal": "1.0.0",
-        "pify": "2.3.0"
+        "gitconfiglocal": "^1.0.0",
+        "pify": "^2.3.0"
       }
     },
     "git-semver-tags": {
@@ -1631,8 +1577,8 @@
       "integrity": "sha512-2jHlJnln4D/ECk9FxGEBh3k44wgYdWjWDtMmJPaecjoRmxKo3Y1Lh8GMYuOPu04CHw86NTAODchYjC5pnpMQig==",
       "dev": true,
       "requires": {
-        "meow": "4.0.1",
-        "semver": "5.5.0"
+        "meow": "^4.0.0",
+        "semver": "^5.5.0"
       },
       "dependencies": {
         "camelcase": {
@@ -1647,9 +1593,9 @@
           "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0",
-            "map-obj": "2.0.0",
-            "quick-lru": "1.1.0"
+            "camelcase": "^4.1.0",
+            "map-obj": "^2.0.0",
+            "quick-lru": "^1.0.0"
           }
         },
         "find-up": {
@@ -1658,7 +1604,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         },
         "indent-string": {
@@ -1673,10 +1619,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "4.0.0",
-            "pify": "3.0.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "map-obj": {
@@ -1691,15 +1637,15 @@
           "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
           "dev": true,
           "requires": {
-            "camelcase-keys": "4.2.0",
-            "decamelize-keys": "1.1.0",
-            "loud-rejection": "1.6.0",
-            "minimist": "1.2.0",
-            "minimist-options": "3.0.2",
-            "normalize-package-data": "2.4.0",
-            "read-pkg-up": "3.0.0",
-            "redent": "2.0.0",
-            "trim-newlines": "2.0.0"
+            "camelcase-keys": "^4.0.0",
+            "decamelize-keys": "^1.0.0",
+            "loud-rejection": "^1.0.0",
+            "minimist": "^1.1.3",
+            "minimist-options": "^3.0.1",
+            "normalize-package-data": "^2.3.4",
+            "read-pkg-up": "^3.0.0",
+            "redent": "^2.0.0",
+            "trim-newlines": "^2.0.0"
           }
         },
         "minimist": {
@@ -1714,8 +1660,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.1",
-            "json-parse-better-errors": "1.0.2"
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
           }
         },
         "path-type": {
@@ -1724,7 +1670,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "3.0.0"
+            "pify": "^3.0.0"
           }
         },
         "pify": {
@@ -1739,9 +1685,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "4.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "3.0.0"
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
           }
         },
         "read-pkg-up": {
@@ -1750,8 +1696,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "3.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
           }
         },
         "redent": {
@@ -1760,8 +1706,8 @@
           "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
           "dev": true,
           "requires": {
-            "indent-string": "3.2.0",
-            "strip-indent": "2.0.0"
+            "indent-string": "^3.0.0",
+            "strip-indent": "^2.0.0"
           }
         },
         "strip-bom": {
@@ -1790,7 +1736,7 @@
       "integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
       "dev": true,
       "requires": {
-        "ini": "1.3.5"
+        "ini": "^1.3.2"
       }
     },
     "glob": {
@@ -1798,12 +1744,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.1",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "globby": {
@@ -1812,12 +1758,12 @@
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "graceful-fs": {
@@ -1837,10 +1783,10 @@
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
+        "async": "^1.4.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.4.4",
+        "uglify-js": "^2.6"
       }
     },
     "har-schema": {
@@ -1853,8 +1799,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
       "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
       "requires": {
-        "ajv": "4.11.8",
-        "har-schema": "1.0.5"
+        "ajv": "^4.9.1",
+        "har-schema": "^1.0.5"
       }
     },
     "has-ansi": {
@@ -1863,7 +1809,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -1882,10 +1828,10 @@
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
       "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
+        "boom": "2.x.x",
+        "cryptiles": "2.x.x",
+        "hoek": "2.x.x",
+        "sntp": "1.x.x"
       }
     },
     "hoek": {
@@ -1910,9 +1856,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
       "requires": {
-        "assert-plus": "0.2.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.2"
+        "assert-plus": "^0.2.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "https-proxy-agent": {
@@ -1921,8 +1867,8 @@
       "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
       "dev": true,
       "requires": {
-        "agent-base": "4.2.0",
-        "debug": "3.1.0"
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -1942,10 +1888,10 @@
       "integrity": "sha1-SHhcUCjeNFKlHEjBLE+UshJKFAc=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "find-parent-dir": "0.3.0",
-        "is-ci": "1.1.0",
-        "normalize-path": "1.0.0"
+        "chalk": "^1.1.3",
+        "find-parent-dir": "^0.3.0",
+        "is-ci": "^1.0.9",
+        "normalize-path": "^1.0.0"
       }
     },
     "iconv-lite": {
@@ -1953,7 +1899,15 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
       "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "ignore-walk": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+      "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+      "requires": {
+        "minimatch": "^3.0.4"
       }
     },
     "immediate": {
@@ -1968,7 +1922,7 @@
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "inflight": {
@@ -1976,8 +1930,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -2008,7 +1962,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-ci": {
@@ -2017,7 +1971,7 @@
       "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
       "dev": true,
       "requires": {
-        "ci-info": "1.1.3"
+        "ci-info": "^1.0.0"
       }
     },
     "is-finite": {
@@ -2026,7 +1980,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -2034,7 +1988,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-obj": {
@@ -2055,7 +2009,7 @@
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.1"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -2064,7 +2018,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-plain-obj": {
@@ -2085,7 +2039,7 @@
       "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
       "dev": true,
       "requires": {
-        "text-extensions": "1.7.0"
+        "text-extensions": "^1.0.0"
       }
     },
     "is-typedarray": {
@@ -2110,11 +2064,6 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-    "isnumeric": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/isnumeric/-/isnumeric-0.2.0.tgz",
-      "integrity": "sha1-ojR7o2DeGeM9D/1ZD933dVy/LmQ="
-    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -2126,20 +2075,20 @@
       "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.9",
-        "async": "1.5.2",
-        "escodegen": "1.8.1",
-        "esprima": "2.7.3",
-        "glob": "5.0.15",
-        "handlebars": "4.0.11",
-        "js-yaml": "3.12.0",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "once": "1.4.0",
-        "resolve": "1.1.7",
-        "supports-color": "3.2.3",
-        "which": "1.3.1",
-        "wordwrap": "1.0.0"
+        "abbrev": "1.0.x",
+        "async": "1.x",
+        "escodegen": "1.8.x",
+        "esprima": "2.7.x",
+        "glob": "^5.0.15",
+        "handlebars": "^4.0.1",
+        "js-yaml": "3.x",
+        "mkdirp": "0.5.x",
+        "nopt": "3.x",
+        "once": "1.x",
+        "resolve": "1.1.x",
+        "supports-color": "^3.1.0",
+        "which": "^1.1.1",
+        "wordwrap": "^1.0.0"
       },
       "dependencies": {
         "abbrev": {
@@ -2154,11 +2103,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.1",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "nopt": {
@@ -2167,7 +2116,7 @@
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
           "dev": true,
           "requires": {
-            "abbrev": "1.0.9"
+            "abbrev": "1"
           }
         },
         "supports-color": {
@@ -2176,7 +2125,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         },
         "wordwrap": {
@@ -2193,9 +2142,9 @@
       "integrity": "sha1-awicChFXax8W3xG4AUbZHU6Lij4=",
       "dev": true,
       "requires": {
-        "exit": "0.1.2",
-        "glob": "7.1.2",
-        "jasmine-core": "2.8.0"
+        "exit": "^0.1.2",
+        "glob": "^7.0.6",
+        "jasmine-core": "~2.8.0"
       }
     },
     "jasmine-core": {
@@ -2225,8 +2174,8 @@
       "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       },
       "dependencies": {
         "esprima": {
@@ -2255,18 +2204,18 @@
       "integrity": "sha1-qAcRlSi0AJzLyrSbdSL2P+xs0L0=",
       "dev": true,
       "requires": {
-        "bluebird": "3.4.7",
-        "catharsis": "0.8.9",
-        "escape-string-regexp": "1.0.5",
-        "espree": "3.1.7",
-        "js2xmlparser": "1.0.0",
-        "klaw": "1.3.1",
-        "marked": "0.3.19",
-        "mkdirp": "0.5.1",
-        "requizzle": "0.2.1",
-        "strip-json-comments": "2.0.1",
+        "bluebird": "~3.4.6",
+        "catharsis": "~0.8.8",
+        "escape-string-regexp": "~1.0.5",
+        "espree": "~3.1.7",
+        "js2xmlparser": "~1.0.0",
+        "klaw": "~1.3.0",
+        "marked": "~0.3.6",
+        "mkdirp": "~0.5.1",
+        "requizzle": "~0.2.1",
+        "strip-json-comments": "~2.0.1",
         "taffydb": "2.6.2",
-        "underscore": "1.8.3"
+        "underscore": "~1.8.3"
       },
       "dependencies": {
         "underscore": {
@@ -2283,17 +2232,17 @@
       "integrity": "sha1-l4/69zvms+32l5nTWZzHaVuCumU=",
       "dev": true,
       "requires": {
-        "array-back": "1.0.4",
-        "cache-point": "0.3.4",
-        "collect-all": "1.0.3",
-        "core-js": "2.5.7",
-        "feature-detect-es6": "1.4.1",
-        "file-set": "1.1.1",
-        "fs-then-native": "1.0.2",
-        "jsdoc-75lb": "3.6.0",
-        "object-to-spawn-args": "1.1.1",
-        "temp-path": "1.0.0",
-        "walk-back": "2.0.1"
+        "array-back": "^1.0.3",
+        "cache-point": "~0.3.4",
+        "collect-all": "^1.0.2",
+        "core-js": "^2.4.1",
+        "feature-detect-es6": "^1.3.1",
+        "file-set": "^1.1.1",
+        "fs-then-native": "^1.0.2",
+        "jsdoc-75lb": "^3.6.0",
+        "object-to-spawn-args": "^1.1.0",
+        "temp-path": "^1.0.0",
+        "walk-back": "^2.0.1"
       }
     },
     "jsdoc-parse": {
@@ -2302,14 +2251,14 @@
       "integrity": "sha1-bUFj6Gk/YFSrQd1M/GQyYJWPFHc=",
       "dev": true,
       "requires": {
-        "array-back": "1.0.4",
-        "core-js": "2.5.7",
-        "feature-detect-es6": "1.4.1",
-        "lodash.omit": "4.5.0",
-        "lodash.pick": "4.4.0",
-        "reduce-extract": "1.0.0",
-        "sort-array": "1.1.2",
-        "test-value": "2.1.0"
+        "array-back": "^1.0.3",
+        "core-js": "^2.4.1",
+        "feature-detect-es6": "^1.3.1",
+        "lodash.omit": "^4.5.0",
+        "lodash.pick": "^4.4.0",
+        "reduce-extract": "^1.0.0",
+        "sort-array": "^1.1.1",
+        "test-value": "^2.1.0"
       }
     },
     "jsdoc-to-markdown": {
@@ -2318,16 +2267,16 @@
       "integrity": "sha1-l+tNcWp3ZPdZWib80zh8hct6uiU=",
       "dev": true,
       "requires": {
-        "array-back": "1.0.4",
-        "command-line-tool": "0.6.4",
-        "config-master": "2.0.4",
-        "core-js": "2.5.7",
-        "dmd": "2.1.2",
-        "feature-detect-es6": "1.4.1",
-        "jsdoc-api": "2.0.6",
-        "jsdoc-parse": "2.0.5",
-        "jsdoc2md-stats": "1.0.6",
-        "walk-back": "2.0.1"
+        "array-back": "^1.0.3",
+        "command-line-tool": "^0.6.4",
+        "config-master": "^2.0.4",
+        "core-js": "^2.4.1",
+        "dmd": "^2.1.2",
+        "feature-detect-es6": "^1.3.1",
+        "jsdoc-api": "^2.0.5",
+        "jsdoc-parse": "^2.0.5",
+        "jsdoc2md-stats": "^1.0.3",
+        "walk-back": "^2.0.1"
       }
     },
     "jsdoc2md-stats": {
@@ -2336,8 +2285,8 @@
       "integrity": "sha1-3A4AKuu9D7rlEjU0+Scyr7xlH78=",
       "dev": true,
       "requires": {
-        "app-usage-stats": "0.4.1",
-        "feature-detect-es6": "1.4.1"
+        "app-usage-stats": "^0.4.0",
+        "feature-detect-es6": "^1.3.1"
       }
     },
     "json-parse-better-errors": {
@@ -2356,7 +2305,7 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -2369,7 +2318,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonify": {
@@ -2407,11 +2356,11 @@
       "integrity": "sha512-5W8NUaFRFRqTOL7ZDDrx5qWHJyBXy6velVudIzQUSoqAAYqzSh2Z7/m0Rf1QbmQJccegD0r+YZxBjzqoBiEeJQ==",
       "dev": true,
       "requires": {
-        "core-js": "2.3.0",
-        "es6-promise": "3.0.2",
-        "lie": "3.1.1",
-        "pako": "1.0.6",
-        "readable-stream": "2.0.6"
+        "core-js": "~2.3.0",
+        "es6-promise": "~3.0.2",
+        "lie": "~3.1.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.0.6"
       },
       "dependencies": {
         "core-js": {
@@ -2444,12 +2393,12 @@
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.1",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "0.10.31",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~0.10.x",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -2466,7 +2415,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "klaw": {
@@ -2474,7 +2423,7 @@
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.9"
       }
     },
     "lazy-cache": {
@@ -2490,8 +2439,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "lie": {
@@ -2500,7 +2449,7 @@
       "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
       "dev": true,
       "requires": {
-        "immediate": "3.0.6"
+        "immediate": "~3.0.5"
       }
     },
     "load-json-file": {
@@ -2509,11 +2458,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
       }
     },
     "locate-path": {
@@ -2522,8 +2471,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       },
       "dependencies": {
         "path-exists": {
@@ -2564,8 +2513,8 @@
       "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.templatesettings": "4.1.0"
+        "lodash._reinterpolate": "~3.0.0",
+        "lodash.templatesettings": "^4.0.0"
       }
     },
     "lodash.templatesettings": {
@@ -2574,7 +2523,7 @@
       "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "3.0.0"
+        "lodash._reinterpolate": "~3.0.0"
       }
     },
     "longest": {
@@ -2589,8 +2538,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
       }
     },
     "lower-case": {
@@ -2616,16 +2565,16 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "2.1.0",
-        "decamelize": "1.2.0",
-        "loud-rejection": "1.6.0",
-        "map-obj": "1.0.1",
-        "minimist": "1.2.0",
-        "normalize-package-data": "2.4.0",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "redent": "1.0.0",
-        "trim-newlines": "1.0.0"
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
       },
       "dependencies": {
         "minimist": {
@@ -2646,7 +2595,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "requires": {
-        "mime-db": "1.33.0"
+        "mime-db": "~1.33.0"
       }
     },
     "minimatch": {
@@ -2654,7 +2603,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -2668,8 +2617,25 @@
       "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
       "dev": true,
       "requires": {
-        "arrify": "1.0.1",
-        "is-plain-obj": "1.1.0"
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0"
+      }
+    },
+    "minipass": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.4.tgz",
+      "integrity": "sha512-mlouk1OHlaUE8Odt1drMtG1bAJA4ZA6B/ehysgV0LUIrDHdKgo1KorZq3pK0b/7Z7LJIQ12MNM6aC+Tn6lUZ5w==",
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+      "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
+      "requires": {
+        "minipass": "^2.2.1"
       }
     },
     "mkdirp": {
@@ -2697,30 +2663,44 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "nan": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
+      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
+    },
+    "needle": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.4.tgz",
+      "integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
+      "requires": {
+        "debug": "^2.1.2",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      }
+    },
     "no-case": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
       "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
       "requires": {
-        "lower-case": "1.1.4"
+        "lower-case": "^1.1.1"
       }
     },
     "node-pre-gyp": {
-      "version": "0.6.39",
-      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
-      "integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz",
+      "integrity": "sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==",
       "requires": {
-        "detect-libc": "1.0.3",
-        "hawk": "3.1.3",
-        "mkdirp": "0.5.1",
-        "nopt": "4.0.1",
-        "npmlog": "4.1.2",
-        "rc": "1.2.8",
-        "request": "2.81.0",
-        "rimraf": "2.6.2",
-        "semver": "5.5.0",
-        "tar": "2.2.1",
-        "tar-pack": "3.4.1"
+        "detect-libc": "^1.0.2",
+        "mkdirp": "^0.5.1",
+        "needle": "^2.2.1",
+        "nopt": "^4.0.1",
+        "npm-packlist": "^1.1.6",
+        "npmlog": "^4.0.2",
+        "rc": "^1.2.7",
+        "rimraf": "^2.6.1",
+        "semver": "^5.3.0",
+        "tar": "^4"
       }
     },
     "nopt": {
@@ -2728,8 +2708,8 @@
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
       "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
       "requires": {
-        "abbrev": "1.1.1",
-        "osenv": "0.1.5"
+        "abbrev": "1",
+        "osenv": "^0.1.4"
       }
     },
     "normalize-package-data": {
@@ -2738,10 +2718,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.6.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.5.0",
-        "validate-npm-package-license": "3.0.3"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -2750,15 +2730,29 @@
       "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
       "dev": true
     },
+    "npm-bundled": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.5.tgz",
+      "integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g=="
+    },
+    "npm-packlist": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.11.tgz",
+      "integrity": "sha512-CxKlZ24urLkJk+9kCm48RTQ7L4hsmgSVzEk0TLGPzzyuFxD7VNgy5Sl24tOLMzQv773a/NeJ1ce1DKeacqffEA==",
+      "requires": {
+        "ignore-walk": "^3.0.1",
+        "npm-bundled": "^1.0.1"
+      }
+    },
     "npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "requires": {
-        "are-we-there-yet": "1.1.5",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "number-is-nan": {
@@ -2793,7 +2787,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "optimist": {
@@ -2802,8 +2796,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       }
     },
     "optionator": {
@@ -2812,12 +2806,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       },
       "dependencies": {
         "wordwrap": {
@@ -2849,8 +2843,8 @@
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
       }
     },
     "p-limit": {
@@ -2859,7 +2853,7 @@
       "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "dev": true,
       "requires": {
-        "p-try": "1.0.0"
+        "p-try": "^1.0.0"
       }
     },
     "p-locate": {
@@ -2868,7 +2862,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.3.0"
+        "p-limit": "^1.1.0"
       }
     },
     "p-try": {
@@ -2882,22 +2876,6 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
       "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
     },
-    "parse-css-font": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/parse-css-font/-/parse-css-font-2.0.2.tgz",
-      "integrity": "sha1-e2CwYHBaJam5C38O1JPlgjJIplI=",
-      "requires": {
-        "css-font-size-keywords": "1.0.0",
-        "css-font-stretch-keywords": "1.0.1",
-        "css-font-style-keywords": "1.0.1",
-        "css-font-weight-keywords": "1.0.0",
-        "css-global-keywords": "1.0.1",
-        "css-list-helpers": "1.0.1",
-        "css-system-font-keywords": "1.0.0",
-        "tcomb": "2.7.0",
-        "unquote": "1.1.1"
-      }
-    },
     "parse-github-repo-url": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
@@ -2910,7 +2888,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.1"
+        "error-ex": "^1.2.0"
       }
     },
     "path-exists": {
@@ -2919,7 +2897,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "2.0.1"
+        "pinkie-promise": "^2.0.0"
       }
     },
     "path-is-absolute": {
@@ -2939,9 +2917,9 @@
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "performance-now": {
@@ -2967,7 +2945,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "png-image": {
@@ -2975,8 +2953,8 @@
       "resolved": "https://registry.npmjs.org/png-image/-/png-image-1.1.1.tgz",
       "integrity": "sha1-Ekjlys8PZfqY5H5Szcev1Xdy3ao=",
       "requires": {
-        "pngjs": "3.3.3",
-        "promise": "6.1.0"
+        "pngjs": "^3.0.0",
+        "promise": "^6.0.1"
       }
     },
     "pngjs": {
@@ -2989,10 +2967,10 @@
       "resolved": "https://registry.npmjs.org/pngjs-image/-/pngjs-image-0.11.7.tgz",
       "integrity": "sha1-Yx3VmSRWn8gv/rrg1dU/hfVNq2I=",
       "requires": {
-        "iconv-lite": "0.4.23",
-        "pako": "0.2.9",
+        "iconv-lite": "^0.4.8",
+        "pako": "^0.2.6",
         "pngjs": "2.3.1",
-        "request": "2.81.0",
+        "request": "^2.55.0",
         "stream-buffers": "1.0.1",
         "underscore": "1.7.0"
       },
@@ -3020,7 +2998,7 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
       "integrity": "sha1-LOcp9rlLRcJoka0GAsXJDgTG7vY=",
       "requires": {
-        "asap": "1.0.0"
+        "asap": "~1.0.0"
       }
     },
     "protractor": {
@@ -3029,21 +3007,21 @@
       "integrity": "sha512-pw4uwwiy5lHZjIguxNpkEwJJa7hVz+bJsvaTI+IbXlfn2qXwzbF8eghW/RmrZwE2sGx82I8etb8lVjQ+JrjejA==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.112",
-        "@types/q": "0.0.32",
-        "@types/selenium-webdriver": "2.53.43",
-        "blocking-proxy": "1.0.1",
-        "chalk": "1.1.3",
-        "glob": "7.1.2",
+        "@types/node": "^6.0.46",
+        "@types/q": "^0.0.32",
+        "@types/selenium-webdriver": "~2.53.39",
+        "blocking-proxy": "^1.0.0",
+        "chalk": "^1.1.3",
+        "glob": "^7.0.3",
         "jasmine": "2.8.0",
-        "jasminewd2": "2.2.0",
-        "optimist": "0.6.1",
+        "jasminewd2": "^2.1.0",
+        "optimist": "~0.6.0",
         "q": "1.4.1",
-        "saucelabs": "1.5.0",
+        "saucelabs": "^1.5.0",
         "selenium-webdriver": "3.6.0",
-        "source-map-support": "0.4.18",
-        "webdriver-js-extender": "1.0.0",
-        "webdriver-manager": "12.0.6"
+        "source-map-support": "~0.4.0",
+        "webdriver-js-extender": "^1.0.0",
+        "webdriver-manager": "^12.0.6"
       },
       "dependencies": {
         "adm-zip": {
@@ -3070,17 +3048,17 @@
           "integrity": "sha1-PfGkgZdwELTL+MnYXHpXeCjA5ws=",
           "dev": true,
           "requires": {
-            "adm-zip": "0.4.11",
-            "chalk": "1.1.3",
-            "del": "2.2.2",
-            "glob": "7.1.2",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "q": "1.4.1",
-            "request": "2.81.0",
-            "rimraf": "2.6.2",
-            "semver": "5.5.0",
-            "xml2js": "0.4.19"
+            "adm-zip": "^0.4.7",
+            "chalk": "^1.1.1",
+            "del": "^2.2.0",
+            "glob": "^7.0.3",
+            "ini": "^1.3.4",
+            "minimist": "^1.2.0",
+            "q": "^1.4.1",
+            "request": "^2.78.0",
+            "rimraf": "^2.5.2",
+            "semver": "^5.3.0",
+            "xml2js": "^0.4.17"
           }
         }
       }
@@ -3112,15 +3090,15 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "requires": {
-        "deep-extend": "0.6.0",
-        "ini": "1.3.5",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -3131,9 +3109,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "1.1.0"
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
       }
     },
     "read-pkg-up": {
@@ -3142,8 +3120,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
       }
     },
     "readable-stream": {
@@ -3151,13 +3129,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.2",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       },
       "dependencies": {
         "inherits": {
@@ -3173,8 +3151,8 @@
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "2.1.0",
-        "strip-indent": "1.0.1"
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
       }
     },
     "reduce-extract": {
@@ -3183,7 +3161,7 @@
       "integrity": "sha1-Z/I4W+2mUGG19fQxJmLosIDKFSU=",
       "dev": true,
       "requires": {
-        "test-value": "1.1.0"
+        "test-value": "^1.0.1"
       },
       "dependencies": {
         "test-value": {
@@ -3192,8 +3170,8 @@
           "integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
           "dev": true,
           "requires": {
-            "array-back": "1.0.4",
-            "typical": "2.6.1"
+            "array-back": "^1.0.2",
+            "typical": "^2.4.2"
           }
         }
       }
@@ -3216,7 +3194,7 @@
       "integrity": "sha1-aK0OrRGFXJo31OglbBW7+Hly/Iw=",
       "dev": true,
       "requires": {
-        "test-value": "2.1.0"
+        "test-value": "^2.0.0"
       }
     },
     "regenerator-runtime": {
@@ -3237,7 +3215,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "req-then": {
@@ -3246,11 +3224,11 @@
       "integrity": "sha1-McbgtW9N3SrNbeC6G86ne2B5398=",
       "dev": true,
       "requires": {
-        "array-back": "1.0.4",
-        "defer-promise": "1.0.1",
-        "feature-detect-es6": "1.4.1",
-        "lodash.pick": "4.4.0",
-        "typical": "2.6.1"
+        "array-back": "^1.0.3",
+        "defer-promise": "^1.0.0",
+        "feature-detect-es6": "^1.3.1",
+        "lodash.pick": "^4.4.0",
+        "typical": "^2.6.0"
       }
     },
     "request": {
@@ -3258,28 +3236,28 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
       "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
       "requires": {
-        "aws-sign2": "0.6.0",
-        "aws4": "1.7.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.1.4",
-        "har-validator": "4.2.1",
-        "hawk": "3.1.3",
-        "http-signature": "1.1.1",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.18",
-        "oauth-sign": "0.8.2",
-        "performance-now": "0.2.0",
-        "qs": "6.4.0",
-        "safe-buffer": "5.1.2",
-        "stringstream": "0.0.6",
-        "tough-cookie": "2.3.4",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.2.1"
+        "aws-sign2": "~0.6.0",
+        "aws4": "^1.2.1",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.0",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.1.1",
+        "har-validator": "~4.2.1",
+        "hawk": "~3.1.3",
+        "http-signature": "~1.1.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.7",
+        "oauth-sign": "~0.8.1",
+        "performance-now": "^0.2.0",
+        "qs": "~6.4.0",
+        "safe-buffer": "^5.0.1",
+        "stringstream": "~0.0.4",
+        "tough-cookie": "~2.3.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.0.0"
       }
     },
     "requizzle": {
@@ -3288,7 +3266,7 @@
       "integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
       "dev": true,
       "requires": {
-        "underscore": "1.6.0"
+        "underscore": "~1.6.0"
       },
       "dependencies": {
         "underscore": {
@@ -3312,7 +3290,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -3320,7 +3298,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "safe-buffer": {
@@ -3339,14 +3317,13 @@
       "integrity": "sha512-jlX3FGdWvYf4Q3LFfFWS1QvPg3IGCGWxIc8QBFdPTbpTJnt/v17FHXYVAn7C8sHf1yUXo2c7yIM0isDryfYtHQ==",
       "dev": true,
       "requires": {
-        "https-proxy-agent": "2.2.1"
+        "https-proxy-agent": "^2.2.1"
       }
     },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "selenium-webdriver": {
       "version": "3.6.0",
@@ -3354,10 +3331,10 @@
       "integrity": "sha512-WH7Aldse+2P5bbFBO4Gle/nuQOdVwpHMTL6raL3uuBj/vPG07k6uzt3aiahu352ONBr5xXh0hDlM3LhtXPOC4Q==",
       "dev": true,
       "requires": {
-        "jszip": "3.1.5",
-        "rimraf": "2.6.2",
+        "jszip": "^3.1.3",
+        "rimraf": "^2.5.4",
         "tmp": "0.0.30",
-        "xml2js": "0.4.19"
+        "xml2js": "^0.4.17"
       }
     },
     "semver": {
@@ -3386,7 +3363,7 @@
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "2.x.x"
       }
     },
     "sort-array": {
@@ -3395,9 +3372,9 @@
       "integrity": "sha1-uImGBTwBcKf53mPxiknsecJMPmQ=",
       "dev": true,
       "requires": {
-        "array-back": "1.0.4",
-        "object-get": "2.1.0",
-        "typical": "2.6.1"
+        "array-back": "^1.0.4",
+        "object-get": "^2.1.0",
+        "typical": "^2.6.0"
       }
     },
     "source-map": {
@@ -3406,7 +3383,7 @@
       "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
       "dev": true,
       "requires": {
-        "amdefine": "1.0.1"
+        "amdefine": ">=0.0.4"
       }
     },
     "source-map-support": {
@@ -3415,7 +3392,7 @@
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "^0.5.6"
       },
       "dependencies": {
         "source-map": {
@@ -3432,8 +3409,8 @@
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "3.0.0",
-        "spdx-license-ids": "3.0.0"
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -3448,8 +3425,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "2.1.0",
-        "spdx-license-ids": "3.0.0"
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -3464,7 +3441,7 @@
       "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
       "dev": true,
       "requires": {
-        "through": "2.3.8"
+        "through": "2"
       }
     },
     "split2": {
@@ -3473,7 +3450,7 @@
       "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
       "dev": true,
       "requires": {
-        "through2": "2.0.3"
+        "through2": "^2.0.2"
       }
     },
     "sprintf-js": {
@@ -3487,15 +3464,15 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -3516,7 +3493,7 @@
       "integrity": "sha1-GLyB8u2zW4tdmoAJIAqYUxRCipc=",
       "dev": true,
       "requires": {
-        "array-back": "1.0.4"
+        "array-back": "^1.0.2"
       }
     },
     "stream-via": {
@@ -3530,9 +3507,9 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "string_decoder": {
@@ -3540,7 +3517,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.1.0"
       }
     },
     "stringstream": {
@@ -3553,7 +3530,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -3562,7 +3539,7 @@
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
-        "is-utf8": "0.2.1"
+        "is-utf8": "^0.2.0"
       }
     },
     "strip-indent": {
@@ -3571,7 +3548,7 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1"
+        "get-stdin": "^4.0.1"
       }
     },
     "strip-json-comments": {
@@ -3591,12 +3568,12 @@
       "integrity": "sha1-buINxIPbNxs+XIf3BO0vfHmdLJo=",
       "dev": true,
       "requires": {
-        "array-back": "1.0.4",
-        "core-js": "2.5.7",
-        "deep-extend": "0.4.2",
-        "feature-detect-es6": "1.4.1",
-        "typical": "2.6.1",
-        "wordwrapjs": "2.0.0"
+        "array-back": "^1.0.3",
+        "core-js": "^2.4.1",
+        "deep-extend": "~0.4.1",
+        "feature-detect-es6": "^1.3.1",
+        "typical": "^2.6.0",
+        "wordwrapjs": "^2.0.0-0"
       },
       "dependencies": {
         "deep-extend": {
@@ -3614,34 +3591,18 @@
       "dev": true
     },
     "tar": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.6.tgz",
+      "integrity": "sha512-tMkTnh9EdzxyfW+6GK6fCahagXsnYk6kE6S9Gr9pjVdys769+laCTbodXDhPAjzVtEBazRgP0gYqOjnk9dQzLg==",
       "requires": {
-        "block-stream": "0.0.9",
-        "fstream": "1.0.11",
-        "inherits": "2.0.1"
+        "chownr": "^1.0.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.3.3",
+        "minizlib": "^1.1.0",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.2"
       }
-    },
-    "tar-pack": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.1.tgz",
-      "integrity": "sha512-PPRybI9+jM5tjtCbN2cxmmRU7YmqT3Zv/UDy48tAh2XRkLa9bAORtSWLkVc13+GJF+cdTh1yEnHEk3cpTaL5Kg==",
-      "requires": {
-        "debug": "2.6.9",
-        "fstream": "1.0.11",
-        "fstream-ignore": "1.0.5",
-        "once": "1.4.0",
-        "readable-stream": "2.3.6",
-        "rimraf": "2.6.2",
-        "tar": "2.2.1",
-        "uid-number": "0.0.6"
-      }
-    },
-    "tcomb": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tcomb/-/tcomb-2.7.0.tgz",
-      "integrity": "sha1-ENYpWAQWaaXVNWe5pO6M3iKxwrA="
     },
     "temp-path": {
       "version": "1.0.0",
@@ -3655,8 +3616,8 @@
       "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
       "dev": true,
       "requires": {
-        "array-back": "1.0.4",
-        "typical": "2.6.1"
+        "array-back": "^1.0.3",
+        "typical": "^2.6.0"
       }
     },
     "text-extensions": {
@@ -3677,8 +3638,8 @@
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.6",
-        "xtend": "4.0.1"
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
       }
     },
     "tmp": {
@@ -3687,7 +3648,7 @@
       "integrity": "sha1-ckGdSovn1s51FI/YsyTlk6cRwu0=",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.1"
       }
     },
     "tough-cookie": {
@@ -3695,7 +3656,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "trim-newlines": {
@@ -3715,7 +3676,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -3730,7 +3691,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "typical": {
@@ -3746,9 +3707,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
       },
       "dependencies": {
         "source-map": {
@@ -3766,11 +3727,6 @@
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "dev": true,
       "optional": true
-    },
-    "uid-number": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-      "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE="
     },
     "ultron": {
       "version": "1.0.2",
@@ -3800,20 +3756,6 @@
         }
       }
     },
-    "units-css": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/units-css/-/units-css-0.4.0.tgz",
-      "integrity": "sha1-1iKGU6UZg9fBb/KPi53Dsf/tOgc=",
-      "requires": {
-        "isnumeric": "0.2.0",
-        "viewport-dimensions": "0.2.0"
-      }
-    },
-    "unquote": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
-      "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ="
-    },
     "upper-case": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
@@ -3825,15 +3767,15 @@
       "integrity": "sha512-QS1r7a1h5g1jo6KulvVGV+eQM+Jfj87AjJBfr1iaIJYz+N7+Qh7ezaVFCulwBGd8T1EidRiSYphG17gra2y0kg==",
       "dev": true,
       "requires": {
-        "array-back": "1.0.4",
+        "array-back": "^1.0.4",
         "cli-commands": "0.1.0",
-        "core-js": "2.5.7",
-        "feature-detect-es6": "1.4.1",
-        "home-path": "1.0.6",
-        "mkdirp2": "1.0.4",
+        "core-js": "^2.4.1",
+        "feature-detect-es6": "^1.3.1",
+        "home-path": "^1.0.5",
+        "mkdirp2": "^1.0.3",
         "req-then": "0.5.1",
-        "typical": "2.6.1",
-        "uuid": "3.2.1"
+        "typical": "^2.6.1",
+        "uuid": "^3.0.1"
       }
     },
     "util": {
@@ -3860,8 +3802,8 @@
       "integrity": "sha1-5Tg2kQEsuycNzAvCpO/+vhSJDqw=",
       "dev": true,
       "requires": {
-        "conventional-commit-types": "2.2.0",
-        "find-parent-dir": "0.3.0",
+        "conventional-commit-types": "^2.0.0",
+        "find-parent-dir": "^0.3.0",
         "findup": "0.1.5",
         "semver-regex": "1.0.0"
       }
@@ -3872,8 +3814,8 @@
       "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
       "dev": true,
       "requires": {
-        "spdx-correct": "3.0.0",
-        "spdx-expression-parse": "3.0.0"
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "verror": {
@@ -3881,9 +3823,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -3892,11 +3834,6 @@
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
-    },
-    "viewport-dimensions": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/viewport-dimensions/-/viewport-dimensions-0.2.0.tgz",
-      "integrity": "sha1-3nQHR9tTh/0XJfUXXpG6x2r982w="
     },
     "walk-back": {
       "version": "2.0.1",
@@ -3910,8 +3847,8 @@
       "integrity": "sha1-gcUzqeM9W/tZe05j4s2yW1R3dRU=",
       "dev": true,
       "requires": {
-        "@types/selenium-webdriver": "2.53.43",
-        "selenium-webdriver": "2.53.3"
+        "@types/selenium-webdriver": "^2.53.35",
+        "selenium-webdriver": "^2.53.2"
       },
       "dependencies": {
         "sax": {
@@ -3927,9 +3864,9 @@
           "dev": true,
           "requires": {
             "adm-zip": "0.4.4",
-            "rimraf": "2.6.2",
+            "rimraf": "^2.2.8",
             "tmp": "0.0.24",
-            "ws": "1.1.5",
+            "ws": "^1.0.1",
             "xml2js": "0.4.4"
           }
         },
@@ -3945,8 +3882,8 @@
           "integrity": "sha1-MREBAAMAiuGSQOuhdJe1fHKcVV0=",
           "dev": true,
           "requires": {
-            "sax": "0.6.1",
-            "xmlbuilder": "9.0.7"
+            "sax": "0.6.x",
+            "xmlbuilder": ">=1.0.0"
           }
         }
       }
@@ -3957,7 +3894,7 @@
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "wide-align": {
@@ -3965,7 +3902,7 @@
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "^1.0.2 || 2"
       }
     },
     "window-size": {
@@ -3987,10 +3924,10 @@
       "integrity": "sha1-q1X2leYRjak4WP3XDAU9HF4BrCA=",
       "dev": true,
       "requires": {
-        "array-back": "1.0.4",
-        "feature-detect-es6": "1.4.1",
-        "reduce-flatten": "1.0.1",
-        "typical": "2.6.1"
+        "array-back": "^1.0.3",
+        "feature-detect-es6": "^1.3.1",
+        "reduce-flatten": "^1.0.1",
+        "typical": "^2.6.0"
       }
     },
     "wrappy": {
@@ -4004,8 +3941,8 @@
       "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
       "dev": true,
       "requires": {
-        "options": "0.0.6",
-        "ultron": "1.0.2"
+        "options": ">=0.0.5",
+        "ultron": "1.0.x"
       }
     },
     "xml2js": {
@@ -4014,8 +3951,8 @@
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "dev": true,
       "requires": {
-        "sax": "1.2.4",
-        "xmlbuilder": "9.0.7"
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
       }
     },
     "xmlbuilder": {
@@ -4030,6 +3967,11 @@
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true
     },
+    "yallist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+      "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+    },
     "yargs": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
@@ -4037,9 +3979,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "camelcase": "1.2.1",
-        "cliui": "2.1.0",
-        "decamelize": "1.2.0",
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
         "window-size": "0.1.0"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "assert": "1.4.1",
     "camel-case": "3.0.0",
-    "canvas-prebuilt": "^1.6.5-prerelease.1",
+    "canvas-prebuilt": "^2.0.0-alpha.14",
     "fs-extra": "1.0.0",
     "png-image": "1.1.1",
     "pngjs-image": "0.11.7"


### PR DESCRIPTION
To fix this issue, which occurs on my system as well, I updated node-canvas-prebuilt to the latest version.
I tried to follow the guidelines about running the tests locally, but because of the issue, the baseline was not created completely by npm run test.init and npm run test.local failed before doing any changes.

I checked the breaking changes listed in https://github.com/Automattic/node-canvas/blob/master/CHANGELOG.md and I could not find anything that is used by protractor-image-comparison. By running the tests after updating, I found that new Canvas() in resemble.js failed, I replaced this by Canvas.createCanvas(). After this fix, 19 of the 20 local tests were successful, only one failed:
1) protractor-image-comparison compare element should compare a canvas screenshot successful with a baseline
  - Failed: Image not found, saving current image as new baseline.

I assume this is because of the failed baseline.
