### PR TITLE
feat: provides async functions to library config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ install:
 
 before_script:
   - npm install
-  - npx webdriver-manager update
 
 script:
   - npm run compile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 sudo: false
 
 os:
-- osx
+  - osx
 
 language: node_js
 node_js:
-- '8'
+  - '8'
 
 addons:
   sauce_connect: true
@@ -18,8 +18,9 @@ install:
 - npm install
 
 before_script:
-- npm install
+  - npm install
+  - npx webdriver-manager update
 
 script:
-- npm run compile
-- npm run test.saucelabs
+  - npm run compile
+  - npm run test.saucelabs

--- a/docs/OPTIONS.md
+++ b/docs/OPTIONS.md
@@ -30,7 +30,26 @@ exports.config = {
 		},
 	],
 };
-``` 
+```
+
+### baselineFolder
+This option can be `string`, `function`, or `async function`.
+For example, we can create custom folder name for every browser instance:
+
+```js
+savePerInstance: false,
+// argument is current plugin options
+baselineFolder: async (options) => {
+  const capabilities = await browser.getCapabilities();
+  const version = capabilities.get('browserVersion') || capabilities.get('version');
+  const browserName = capabilities.get('browserName');
+
+  if (IS_HEADLESS) {
+    return `desktop_${ browserName }_headless`
+  }
+  return `desktop_${ browserName }_${ version }`
+}
+```
 
 ## Method options
 Methods options are the options that can be set per method. If the option has the same key as an options that has been set during the instantiation of the plugin, this method option will override the plugin option value.

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -9,7 +9,7 @@ import ProtractorImageComparison from './protractor.image.compare';
 async function setup() {
 	const configOptions: ClassOptions = typeof this.config.options === 'object' ? this.config.options : {};
 
-	browser.imageComparison = new ProtractorImageComparison(configOptions);
+	browser.imageComparison = await ProtractorImageComparison.build(configOptions);
 }
 
 exports.setup = setup;

--- a/lib/protractor.image.compare.ts
+++ b/lib/protractor.image.compare.ts
@@ -17,11 +17,22 @@ import {
 	getInstanceData,
 	optionElementsToWebElements,
 	getWebElements,
+	isAsyncFn,
 } from './utils';
 
 export default class ProtractorImageComparison extends BaseClass {
-	constructor(options: ClassOptions) {
-		super(options);
+
+	/**
+	 * @description This method create new ProtractorImageComparison instance
+	 * and provides to use async functions in library options
+	 */
+	static async build(options: ClassOptions): Promise<ProtractorImageComparison> {
+		const instance = new ProtractorImageComparison(options);
+		if (options.baselineFolder && isAsyncFn(options.baselineFolder)) {
+			const baselineFolderPath = await options.baselineFolder(options);
+			instance.folders.baselineFolder = baselineFolderPath;
+		}
+		return instance;
 	}
 
 	/**

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,7 +1,5 @@
 import {browser, ElementFinder} from "protractor";
 import {SaveFullPageMethodOptions} from "webdriver-image-comparison/build/commands/fullPage.interfaces";
-import {SaveElementMethodOptions} from "webdriver-image-comparison/build/commands/element.interfaces";
-import {SaveScreenMethodOptions} from "webdriver-image-comparison/build/commands/screen.interfaces";
 
 
 /**
@@ -86,4 +84,8 @@ export function getFolders(
 		baselineFolder: (methodOptions.baselineFolder ? methodOptions.baselineFolder : folders.baselineFolder),
 		diffFolder: (methodOptions.diffFolder ? methodOptions.diffFolder : folders.diffFolder)
 	};
+}
+
+export function isAsyncFn(fn: () => void) {
+	return fn.constructor.name === 'AsyncFunction';
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -86,6 +86,9 @@ export function getFolders(
 	};
 }
 
-export function isAsyncFn(fn: () => void) {
+/**
+ * @description Detect if a function is asynchronous
+ */
+export function isAsyncFn(fn: () => void): boolean {
 	return fn.constructor.name === 'AsyncFunction';
 }


### PR DESCRIPTION
**Suggestion:**
I use browserstack service for visual regression testing with different versions of same browser (e.g. Chrome 78, 49). The library can save images only per instance name (desktop_chrome, desktop_firefox, etc.). The browserstack has own [capabilities](https://www.browserstack.com/automate/capabilities) format and I can't break it. 

**Solution:**
I can disable `savePerInstance` option and create own format with using callback function for `baselineFolder`. (e.g. get data from capabilities). But I can't do this because callback function cannot be async. This PR will fix it.

From example below I can do the follow thing:

```typescript
savePerInstance: false,
baselineFolder: async () => {
  const capabilities = await browser.getCapabilities();
  const version = capabilities.get('browserVersion') || capabilities.get('version');
  const browserName = capabilities.get('browserName');
  if (IS_HEADLESS) {
    return `desktop_${ browserName }_headless`
  }
  return `desktop_${ browserName }_${ version }`
}
```

**Small note:**
I did this feature only for `baselineFolder`, but it easily extended for other properties.
Also I tried fix travis config and get rid of unused imports.

UPD: Travis still not working :(